### PR TITLE
change Decimal to output numeric types

### DIFF
--- a/lib/apipie/validator.rb
+++ b/lib/apipie/validator.rb
@@ -427,6 +427,10 @@ module Apipie
         "Must be a decimal number."
       end
 
+      def expected_type
+        'numeric'
+      end
+
       def self.validate(value)
         value.to_s =~ /\A^[-+]?[0-9]+([,.][0-9]+)?\Z$/
       end


### PR DESCRIPTION
This change makes decimal annotated fields output the swagger type as `number` instead of `string`. 

This makes both our API docs and TypeScript types more intuitive. We currently do a lot of `.toString()` calls in our frontend app to work around this problem.