### PR TITLE
Prevent the use of ProcValidator on response parameters

### DIFF
--- a/lib/apipie/param_description.rb
+++ b/lib/apipie/param_description.rb
@@ -91,6 +91,7 @@ module Apipie
           raise "an ':array_of =>' validator is allowed exclusively on response-only fields" unless @response_only
         end
         @validator = Validator::BaseValidator.find(self, validator, @options, block)
+        raise "Proc validators not supported on param #{method_description.id}:#{name}" if (@validator.is_a? Validator::ProcValidator) && @response_only
         raise "Validator for #{validator} not found." unless @validator
       end
 

--- a/lib/apipie/version.rb
+++ b/lib/apipie/version.rb
@@ -1,3 +1,3 @@
 module Apipie
-  VERSION = '0.5.19'
+  VERSION = '0.5.18'
 end

--- a/lib/apipie/version.rb
+++ b/lib/apipie/version.rb
@@ -1,3 +1,3 @@
 module Apipie
-  VERSION = '0.5.18'
+  VERSION = '0.5.19'
 end

--- a/spec/lib/param_description_spec.rb
+++ b/spec/lib/param_description_spec.rb
@@ -111,6 +111,11 @@ describe Apipie::ParamDescription do
       expect(param.validator).to eq(:validator_instance)
     end
 
+    it "should not allow proc validators on response_only params" do
+      expect { Apipie::ParamDescription.new(method_desc, :param, lambda { |val|
+        true
+      }, :only_in => :response) }.to raise_error(RuntimeError, /Proc validators not supported.*/)
+    end
   end
 
   describe "concern substitution" do


### PR DESCRIPTION
Response validation takes place by doing JSON validation against the Swagger schema - as such, ProcValidators don't make sense.

In fact, `match_declared_responses` will fail in some cases, since the validator will default to indicating the valid JSON type will be `string` (as it's the default `expected_type` and `ProcValidator` doesn't set it - which it can't, since it can run on arbitrary types).