### PR TITLE
[ADS-12302] Add OneOf validator with OpenAPI gen support

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1317,6 +1317,27 @@ description of nested values.
    end
 
 
+OneOfValidator
+-------------
+
+// TODO: More info here
+
+.. code:: ruby
+
+   param :pet, :one_of, :desc => "Pet info" do
+     # Param names do not have an effect on validation functionality, but they are included in
+     # OpenAPI schema output
+     param :dog, Hash do
+       param :type, ["dog"], required: true
+       param :barks, :boolean, required: true
+     end
+     param :cat, Hash do
+       param :type, ["cat"], required: true
+       param :meows, :boolean, required: true
+     end
+   end
+
+
 
 Adding custom validator
 -----------------------

--- a/README.rst
+++ b/README.rst
@@ -1318,25 +1318,57 @@ description of nested values.
 
 
 OneOfValidator
--------------
+--------------
 
-// TODO: More info here
+Check if the parameter is exactly one of the param types defined in the provided block.
+
+Important notes:
+  - The name of child params does not have an effect on validation behaviour, but it will affect the name of refs to Hash params in OpenAPI schema generation.
+
+Additional options
+~~~~~~~~~~~~~~~~~~
+
+discriminator_property
+  The name of the property used to discriminate between the different schemas. This is translated to the `discriminator.propertyName <https://swagger.io/specification/#discriminator-object>`_ field in OpenAPI schema generation. It does not have an effect on the behaviour of Apipie validation.
+
+discriminator (on ``Hash`` children only)
+  The value of ``discriminator_property`` that indicates this validator should be used. Again, this does not have an effect on Apipie validation; it only affects OpenAPI schema generation.
+
+Examples
+~~~~~~~~
+
+Primitive types
 
 .. code:: ruby
 
-   param :pet, :one_of, :desc => "Pet info" do
-     # Param names do not have an effect on validation functionality, but they are included in
-     # OpenAPI schema output
-     param :dog, Hash do
+   param :int_or_string, :one_of, do
+     param nil, Integer
+     param nil, String
+   end
+
+Discriminated union
+
+.. code:: ruby
+
+   param :pet, :one_of, :desc => "Pet info", :discriminator_property => :type do
+     param :dog, Hash, discriminator: "dog" do
        param :type, ["dog"], required: true
        param :barks, :boolean, required: true
      end
-     param :cat, Hash do
+     param :cat, Hash, discriminator: "cat" do
        param :type, ["cat"], required: true
        param :meows, :boolean, required: true
      end
    end
 
+Using a single child validator to define a nested array type
+
+.. code:: ruby
+
+   # Validates values like `[[1, 2, 3], [4, 5, 6]]`
+   param :array_of_array_of_integer, Array, of: :one_of do
+     param nil, Array, of: Integer
+   end
 
 
 Adding custom validator

--- a/lib/apipie-rails.rb
+++ b/lib/apipie-rails.rb
@@ -19,6 +19,7 @@ require "apipie/response_description_adapter"
 require "apipie/see_description"
 require "apipie/tag_list_description"
 require "apipie/validator"
+require "apipie/validator/one_of_validator"
 require "apipie/railtie"
 require 'apipie/extractor'
 require "apipie/version"

--- a/lib/apipie/validator/one_of_validator.rb
+++ b/lib/apipie/validator/one_of_validator.rb
@@ -52,10 +52,6 @@ module Apipie
         end
       end
 
-      def expected_type
-        'array'
-      end
-
       def swagger_type
         @type
       end
@@ -64,7 +60,7 @@ module Apipie
 
       def valid_param_for(value)
         error = nil
-        result = params_ordered.find do |param|
+        result = params_ordered.select do |param|
           begin
             param.validator.validate(value)
           rescue Apipie::ParamError => e
@@ -73,7 +69,9 @@ module Apipie
           end
         end
 
-        return result unless result.nil?
+        raise Apipie::ParamInvalid.new(param_name, value, 'Matched multiple validators') if result.size > 1
+        return result.first unless result.empty?
+
         raise error unless error.nil?
 
         nil

--- a/lib/apipie/validator/one_of_validator.rb
+++ b/lib/apipie/validator/one_of_validator.rb
@@ -1,0 +1,83 @@
+module Apipie
+  module Validator
+    class OneOfValidator < BaseValidator
+      include Apipie::DSL::Base
+      include Apipie::DSL::Param
+
+      VALIDATOR_TYPE = :one_of
+
+      def self.build(param_description, argument, _options, block)
+        return unless argument == VALIDATOR_TYPE && block.is_a?(Proc) && block.arity <= 0
+
+        validator_instance = new(param_description, block)
+
+        # A OneOfValidator with a single param is equivalent to the validator for that param alone,
+        # so we return that param's validator directly
+        if validator_instance.params_ordered.count == 1
+          validator_instance.params_ordered.first.validator
+        else
+          validator_instance
+        end
+      end
+
+      def initialize(param_description, block)
+        raise ArgumentError, 'A block must be provided' unless block.present? && block.is_a?(Proc)
+
+        super(param_description)
+
+        @proc = block
+        @type = :oneOf
+
+        instance_exec(&@proc)
+      end
+
+      def validate(value)
+        valid_param_for(value).present?
+      end
+
+      def process_value(value)
+        param = valid_param_for(value)
+        return value unless param
+
+        param.process_value(value)
+      end
+
+      def description
+        'Must match one of the specified validators'
+      end
+
+      def params_ordered
+        @params_ordered ||= _apipie_dsl_data[:params].map do |args|
+          Apipie::ParamDescription.from_dsl_data(param_description.method_description, args)
+        end
+      end
+
+      def expected_type
+        'array'
+      end
+
+      def swagger_type
+        @type
+      end
+
+      private
+
+      def valid_param_for(value)
+        error = nil
+        result = params_ordered.find do |param|
+          begin
+            param.validator.validate(value)
+          rescue Apipie::ParamError => e
+            error = e
+            false
+          end
+        end
+
+        return result unless result.nil?
+        raise error unless error.nil?
+
+        nil
+      end
+    end
+  end
+end

--- a/spec/dummy/app/controllers/pets_one_of_controller.rb
+++ b/spec/dummy/app/controllers/pets_one_of_controller.rb
@@ -1,0 +1,100 @@
+class PetsOneOfController < ApplicationController
+  resource_description do
+    description 'A controller to test discriminated unions with the OneOfValidator'
+    short 'Pets'
+    path '/pets'
+
+    param :common_param, Integer, desc: 'A param that can optionally be passed to all Pet methods', required: false
+
+    returns code: 404 do
+      property :error_message, String, 'description of the error'
+    end
+  end
+
+  def_param_group :pet_common do
+    param :name, String, desc: 'Name of pet'
+    param :age, Integer, desc: 'Age of pet in years'
+  end
+
+  def_param_group :dog do
+    param :animal_type, ['dog'], desc: 'Type of pet'
+    param_group :pet_common, PetsOneOfController
+    param :bark_volume, :decimal, desc: "The average volume of the dog's bark in decibels"
+    param :tag_id, :one_of do
+      param nil, Integer
+      param nil, String
+    end
+  end
+
+  def_param_group :cat do
+    param :animal_type, ['cat'], desc: 'Type of pet'
+    param_group :pet_common, PetsOneOfController
+    param :meow_frequency, :decimal, desc: "The fundamental frequency of the cat's meow in hertz"
+  end
+
+  def_param_group :pet do
+    param :data, :one_of, discriminator_property: :animal_type do
+      param :dog, Hash, discriminator: 'dog' do
+        param_group :dog, PetsOneOfController
+      end
+      param :cat, Hash, discriminator: 'cat' do
+        param_group :cat, PetsOneOfController
+      end
+    end
+  end
+
+  def_param_group :index_pets_response do
+    param :data, Array, of: :one_of, discriminator_property: :animal_type do
+      param :dog, Hash, discriminator: 'dog' do
+        param_group :dog, PetsOneOfController
+      end
+      param :cat, Hash, discriminator: 'cat' do
+        param_group :cat, PetsOneOfController
+      end
+    end
+  end
+
+  def_param_group :show_pet_response do
+    param_group :pet, PetsOneOfController
+  end
+  
+  def_param_group :create_pet_request do
+    param_group :pet, PetsOneOfController
+  end
+
+  def_param_group :created_by_day_response do
+    # Defining a nested array type with one_of
+    param :data, Array, of: :one_of do
+      param :point, Array, of: Hash do
+        property :date, String
+        property :count, Integer
+      end
+    end
+  end
+
+  api :GET, '/pets', 'Retrieve all pets'
+  returns :index_pets_response
+  def index
+    render plain: "OK #{params.inspect}"
+  end
+
+  api :GET, '/pets/:id', 'Retrieve a pet by ID'
+  returns :show_pet_response
+  def show
+    render plain: "OK #{params.inspect}"
+  end
+
+  api :POST, '/pets', 'Create a new pet'
+  param_group :create_pet_request
+  returns :show_pet_response
+  def create
+    render plain: "OK #{params.inspect}"
+  end
+
+  api :GET, '/pets/created_by_day', 'Create a new pet'
+  returns :created_by_day_response
+  def created_by_day
+    render plain: "OK #{params.inspect}"
+  end
+end
+

--- a/spec/dummy/config/initializers/apipie.rb
+++ b/spec/dummy/config/initializers/apipie.rb
@@ -107,4 +107,8 @@ class Apipie::Validator::IntegerValidator < Apipie::Validator::BaseValidator
   def expected_type
     'numeric'
   end
+
+  def swagger_type
+    'long'
+  end
 end

--- a/spec/lib/swagger/swagger_dsl_spec.rb
+++ b/spec/lib/swagger/swagger_dsl_spec.rb
@@ -286,7 +286,7 @@ describe "Swagger Responses" do
         expect(response[:description]).to eq("OK")
 
         schema = response[:schema]
-        expect(schema).to have_field(:pet_id, 'number', {:description => 'id of pet'})
+        expect(schema).to have_field(:pet_id, 'integer', {:description => 'id of pet'})
         expect(schema).to have_field(:pet_name, 'string', {:description => 'Name of pet', :required => false})
         expect(schema).to have_field(:animal_type, 'string', {:description => 'Type of pet', :enum => ['dog','cat','iguana','kangaroo']})
         expect(schema).not_to have_field(:partial_match_allowed, 'boolean', {:required => false})
@@ -294,10 +294,10 @@ describe "Swagger Responses" do
 
       it "creates a swagger definition with all input parameters" do
         # a parameter defined for this method
-        expect(swagger_param_by_name(:pet_id, '/pets/pet_by_id')[:schema][:type]).to eq('number')
+        expect(swagger_param_by_name(:pet_id, '/pets/pet_by_id')[:schema][:type]).to eq('integer')
 
         # a parameter defined for the resource
-        expect(swagger_param_by_name(:common_param, '/pets/pet_by_id')[:schema][:type]).to eq('number')
+        expect(swagger_param_by_name(:common_param, '/pets/pet_by_id')[:schema][:type]).to eq('integer')
 
         # a parameter defined in the controller's superclass
         expect(swagger_param_by_name(:oauth, '/pets/pet_by_id')[:schema][:type]).to eq('string')
@@ -375,9 +375,9 @@ describe "Swagger Responses" do
         expect(schema).to have_field(:pet_measurements, 'object')
 
         pm_schema = schema[:properties][:pet_measurements]
-        expect(pm_schema).to have_field(:weight, 'number', {:description => "Weight in pounds"})
-        expect(pm_schema).to have_field(:height, 'number', {:description => "Height in inches"})
-        expect(pm_schema).to have_field(:num_legs, 'number', {:description => "Number of legs", :required => false})
+        expect(pm_schema).to have_field(:weight, 'integer', {:description => "Weight in pounds"})
+        expect(pm_schema).to have_field(:height, 'integer', {:description => "Height in inches"})
+        expect(pm_schema).to have_field(:num_legs, 'integer', {:description => "Number of legs", :required => false})
       end
 
       it "should return code 203 with spread out 'pet', encapsulated 'pet_measurements' and encapsulated 'pet_history'" do
@@ -406,9 +406,9 @@ describe "Swagger Responses" do
         expect(schema).to have_field(:additional_histories, 'array')
 
         pm_schema = schema[:properties][:pet_measurements]
-        expect(pm_schema).to have_field(:weight, 'number', {:description => "Weight in pounds"})
-        expect(pm_schema).to have_field(:height, 'number', {:description => "Height in inches"})
-        expect(pm_schema).to have_field(:num_legs, 'number', {:description => "Number of legs", :required => false})
+        expect(pm_schema).to have_field(:weight, 'integer', {:description => "Weight in pounds"})
+        expect(pm_schema).to have_field(:height, 'integer', {:description => "Height in inches"})
+        expect(pm_schema).to have_field(:num_legs, 'integer', {:description => "Number of legs", :required => false})
 
         ph_schema = schema[:properties][:pet_history]
         expect(ph_schema).to have_field(:did_visit_vet, 'boolean')
@@ -434,7 +434,7 @@ describe "Swagger Responses" do
         response = swagger_response_for('/pets/{id}/extra_info', 204)
 
         schema = response[:schema]
-        expect(schema).to have_field(:int_array, 'array', {items: {type: 'number'}})
+        expect(schema).to have_field(:int_array, 'array', {items: {type: 'integer', format: 'int64'}})
         expect(schema).to have_field(:enum_array, 'array', {items: {type: 'string', enum: ['v1','v2','v3']}})
       end
 
@@ -457,7 +457,7 @@ describe "Swagger Responses" do
         schema = response[:schema]
         expect(schema).to have_field(:pet_name, 'string', {:required => false})
         expect(schema).to have_field(:animal_type, 'string')
-        expect(schema).to have_field(:num_fleas, 'number')
+        expect(schema).to have_field(:num_fleas, 'integer')
       end
 
     end

--- a/spec/lib/swagger/swagger_gen_one_of_spec.rb
+++ b/spec/lib/swagger/swagger_gen_one_of_spec.rb
@@ -1,0 +1,74 @@
+require 'spec_helper'
+require 'json-schema'
+
+require File.expand_path('../../../dummy/app/controllers/pets_one_of_controller.rb', __FILE__)
+
+describe 'one of swagger gen' do
+  include_context 'rake'
+
+  let(:doc_path) { 'user_specified_doc_path' }
+
+  before do
+    Apipie.configuration.doc_path = doc_path
+    Apipie.configuration.swagger_suppress_warnings = true
+    allow(Apipie).to receive(:reload_documentation)
+    subject.invoke(*task_args)
+  end
+
+  after do
+    Dir["#{doc_output}*"].each { |static_file| FileUtils.rm_rf(static_file) }
+  end
+
+  let(:swagger_schema) do
+    File.read(File.join(File.dirname(__FILE__), 'openapi_3_0_schema.json'))
+  end
+
+  let(:apidoc_swagger_json) do
+    # note:  the filename ends with '_tmp' because this suffix is passed as a parameter to the rake task
+    File.read("#{doc_output}/schema_swagger_tmp.json")
+  end
+
+  let(:apidoc_swagger) do
+    HashWithIndifferentAccess.new(JSON.parse(apidoc_swagger_json))
+  end
+
+  let(:doc_output) do
+    File.join(::Rails.root, doc_path, 'apidoc')
+  end
+
+  describe 'apipie:static_swagger_json[development,json,_tmp]' do
+    it 'generates a valid swagger file' do
+      expect(JSON::Validator.validate(swagger_schema, apidoc_swagger_json)).to be_truthy
+    end
+
+    it 'generates static swagger files for the default version of apipie docs' do
+      expect(apidoc_swagger['info']['title']).to eq('Test app (params in:body)')
+      expect(apidoc_swagger['info']['version']).to eq Apipie.configuration.default_version.to_s
+    end
+
+    it 'includes expected paths' do
+      paths = apidoc_swagger['paths']
+      expect(paths['/pets'].values.count).to be 2
+      expect(paths['/pets/{id}'].values.count).to be 1
+    end
+
+    it 'includes expected schemas' do
+      schemas = apidoc_swagger['components']['schemas']
+
+      expect(schemas['get_pets_param_tag_id']['oneOf']).to match_array [{ type: 'integer', format: 'int64' },
+                                                                        { type: 'string' }]
+
+      expect(schemas['get_pets_param_data']['oneOf']).to match_array [{ "$ref": '#/components/schemas/get_pets_param_dog' },
+                                                                      { "$ref": '#/components/schemas/get_pets_param_cat' }]
+      expect(schemas['get_pets_param_data']['discriminator']['propertyName']).to eq 'animal_type'
+      expect(schemas['get_pets_param_data']['discriminator']['mapping'].keys).to match_array %w[dog cat]
+
+      expect(schemas['get_pets_param_dog']['type']).to eq 'object'
+      expect(schemas['get_pets_param_cat']['type']).to eq 'object'
+
+      expect(schemas.dig(:created_by_day_response, :properties, :data, :type)).to eq 'array'
+      expect(schemas.dig(:created_by_day_response, :properties, :data, :items, :type)).to eq 'array'
+      expect(schemas.dig(:created_by_day_response, :properties, :data, :items, :items, :'$ref')).to eq '#/components/schemas/get_pets_created_by_day_param_point'
+    end
+  end
+end

--- a/spec/lib/validators/array_validator_spec.rb
+++ b/spec/lib/validators/array_validator_spec.rb
@@ -3,7 +3,10 @@ require 'spec_helper'
 module Apipie::Validator
   describe ArrayValidator do
 
-    let(:param_desc) { double(:param_desc) }
+    let(:dsl_data) { ActionController::Base.send(:_apipie_dsl_data_init) }
+    let(:resource_desc) { Apipie::ResourceDescription.new(UsersController, 'users') }
+    let(:method_desc) { Apipie::MethodDescription.new(:show, resource_desc, dsl_data) }
+    let(:param_desc) { Apipie::ParamDescription.new(method_desc, :param, nil) }
 
     context "with no constraint" do
       let(:validator) { ArrayValidator.new(param_desc, Array) }

--- a/spec/lib/validators/one_of_validator_spec.rb
+++ b/spec/lib/validators/one_of_validator_spec.rb
@@ -1,0 +1,128 @@
+require 'spec_helper'
+
+describe Apipie::Validator::OneOfValidator do
+  before do
+    Apipie.configuration.validate = true
+    Apipie.configuration.validate_presence = true
+    Apipie.configuration.validate_value = true
+  end
+
+  let(:dsl_data) { ActionController::Base.send(:_apipie_dsl_data_init) }
+  let(:resource_desc) { Apipie::ResourceDescription.new(UsersController, 'users') }
+  let(:method_desc) { Apipie::MethodDescription.new(:show, resource_desc, dsl_data) }
+  let(:param_desc) { Apipie::ParamDescription.new(method_desc, :param, nil) }
+  let(:argument) { described_class::VALIDATOR_TYPE }
+
+  before do
+    Apipie.add_param_group UsersController, :param_group_a do
+      param :str, String, required: true
+      param :int, Integer, required: true
+    end
+
+    Apipie.add_param_group UsersController, :param_group_b do
+      param :id, :number, required: true
+      param :name, String, required: true
+      param :email, String
+    end
+  end
+
+  it 'throws an error when no block is provided' do
+    expect { described_class.new(param_desc, nil) }.to raise_error ArgumentError
+  end
+
+  it 'works with a single primitive type' do
+    validator = described_class.new(param_desc, lambda {
+      param :str, String
+    })
+    expect(validator.params_ordered.size).to be 1
+    expect(validator.validate('hello')).to be true
+    expect(validator.validate(20)).to be false
+  end
+
+  it 'works with multiple primitive types' do
+    validator = described_class.new(param_desc, lambda {
+      param nil, String
+      param nil, Integer
+    })
+    expect(validator.params_ordered.size).to be 2
+    expect(validator.validate('hello')).to be true
+    expect(validator.validate(20)).to be true
+    expect(validator.validate(13.4)).to be false
+  end
+
+  it 'works with enum validators' do
+    validator = described_class.new(param_desc, lambda {
+      param nil, ['foo', 10]
+      param nil, [20, 'bar']
+      param nil, Integer
+    })
+    expect(validator.validate('foo')).to be true
+    expect(validator.validate(10)).to be true
+    expect(validator.validate(20)).to be true
+    expect(validator.validate('bar')).to be true
+    expect(validator.validate('something else')).to be false
+    expect(validator.validate(300)).to be true
+  end
+
+  it 'accepts arguments for validators' do
+    validator = described_class.new(param_desc, lambda {
+      param :hash, Hash, desc: 'hash param' do
+        param :foo, Integer
+        param :bar, String
+      end
+      param :array_of_hash, Array, desc: 'array of hash param' do
+        param :id, Integer, required: true
+        param :name, String, required: true
+      end
+      param :array_of_int, Array, of: Integer, desc: 'array of int param'
+    })
+
+    expect(validator.validate({ foo: 5, bar: 'foo' })).to be true
+    expect { validator.validate({ foo: 'bar', bar: 3 }) }.to raise_error Apipie::ParamError
+
+    expect(validator.validate([{ id: 1, name: 'John Doe' }, { id: 2, name: 'Jane Doe' }])).to be true
+    expect do
+      validator.validate([{ id: 1, name: 'John Doe' }, { invalid: 'key' }])
+    end.to raise_error Apipie::ParamError
+
+    expect(validator.validate([10, 20, 30])).to be true
+    expect(validator.validate([10, 20, 'foo'])).to be false
+  end
+
+  it 'ignores earlier validators that raise if a subsequent validator passes' do
+    validator = described_class.new(param_desc, lambda {
+      param :int_hash, Hash do
+        param :foo, Integer
+      end
+      param :string_hash, Hash do
+        param :foo, String
+      end
+    })
+
+    expect(validator.validate({ foo: 'foo' })).to be true
+    expect(validator.validate({ foo: 20 })).to be true
+    expect { validator.validate({ foo: {} }) }.to raise_error Apipie::ParamError
+  end
+
+
+  it 'works with param group references' do
+    validator = described_class.new(param_desc, lambda {
+      param nil, Hash do
+        param_group :param_group_b, UsersController
+      end
+      param nil, Hash do
+        param_group :param_group_a, UsersController
+      end
+      param nil, [false]
+    })
+
+    expect(validator.validate({ str: 'string', int: 20 })).to be true
+    expect(validator.validate({ id: 20, name: 'John Doe' })).to be true
+    expect(validator.validate({ id: 20, name: 'John Doe', email: 'john.doe@example.com' })).to be true
+    expect(validator.validate(false)).to be true
+
+    expect { validator.validate({ str: 20, int: 20 }) }.to raise_error Apipie::ParamError
+    expect { validator.validate({ id: 20 }) }.to raise_error Apipie::ParamError
+    expect { validator.validate({ id: 20, name: 'John Doe', email: false }) }.to raise_error Apipie::ParamError
+  end
+end

--- a/spec/lib/validators/one_of_validator_spec.rb
+++ b/spec/lib/validators/one_of_validator_spec.rb
@@ -54,14 +54,12 @@ describe Apipie::Validator::OneOfValidator do
     validator = described_class.new(param_desc, lambda {
       param nil, ['foo', 10]
       param nil, [20, 'bar']
-      param nil, Integer
     })
     expect(validator.validate('foo')).to be true
     expect(validator.validate(10)).to be true
     expect(validator.validate(20)).to be true
     expect(validator.validate('bar')).to be true
     expect(validator.validate('something else')).to be false
-    expect(validator.validate(300)).to be true
   end
 
   it 'accepts arguments for validators' do
@@ -124,5 +122,23 @@ describe Apipie::Validator::OneOfValidator do
     expect { validator.validate({ str: 20, int: 20 }) }.to raise_error Apipie::ParamError
     expect { validator.validate({ id: 20 }) }.to raise_error Apipie::ParamError
     expect { validator.validate({ id: 20, name: 'John Doe', email: false }) }.to raise_error Apipie::ParamError
+  end
+
+  it 'marks values that match multiple validators as invalid' do
+    validator = described_class.new(param_desc, lambda {
+      param nil, Hash do
+        param :foo, String, required: true
+        param :baz, String
+      end
+      param nil, Hash do
+        param :bar, Integer, required: true
+      end
+    })
+
+    expect(validator.validate({ foo: 'bar' })).to be true
+    expect(validator.validate({ foo: 'bar', baz: 'bar2' })).to be true
+    expect(validator.validate({ bar: 12 })).to be true
+
+    expect { validator.validate({ foo: 'bar', bar: 20 }) }.to raise_error Apipie::ParamError
   end
 end


### PR DESCRIPTION
### Context
https://instacart.atlassian.net/browse/ADS-12302
Ads Platform PR using this version of Apipie: https://github.com/instacart/carrot/pull/173204

### Changes

This PR adds a new built-in validator, `OneOfValidator`, which allows a param to be checked against multiple validators. A value will pass validation only if exactly one of the specified validators passes.

Support for OpenAPI/Swagger schema generation is included as well. `OneOfValidator` fields will be translated to a [`oneOf` schema](https://swagger.io/docs/specification/data-models/oneof-anyof-allof-not/).

`ArrayValidator` and `NestedValidator` have also been updated to support any validator type in the `:of` parameter. This allows `OneOfValidator` to be used on arrays.

Building a `OneOfValidator` with a single param definition defers to that parameter definition alone. This allows nested array types to be specified like so:

```ruby
# This validates values like [ [1, 2, 3, 4], [5, 6, 7, 8] ]
param :my_nested_array, Array, of: :one_of do
  param nil, Array, of: Integer
end
```

As a consequence of making array validators more generic, we get the following additional benefits:

- Arrays of enums are now properly typed in OpenAPI schema generation. Previously such parameters were output with
  ```json
  {
    "type": "array",
    "items": {
      "type": "string"
    }
  }
  ```
  Now these parameters will be generated as
  ```json
  {
    "type": "array",
    "items": {
      "type": "string",
      "enum": ["enum", "values", "here"]
    }
  }
  ```
- `Integer` values are now output with `{ "type": "integer" }` for both arrays and plain params in OpenAPI schema generation. Previously only arrays would output `{ "type": "integer" }` while plain params would output `{ "type": "number" }`.

