### PR TITLE
Make the generated swagger file more valid

### DIFF
--- a/lib/apipie/swagger_generator.rb
+++ b/lib/apipie/swagger_generator.rb
@@ -744,7 +744,7 @@ module Apipie
         header_hash = {
           name: header[:name],
           in: 'header',
-          required: header[:options][:required],
+          required: !!header[:options][:required],
           description: header[:description],
           schema: {
             type: header[:options][:type] || 'string'

--- a/spec/controllers/apipies_controller_spec.rb
+++ b/spec/controllers/apipies_controller_spec.rb
@@ -144,7 +144,7 @@ describe Apipie::ApipiesController do
       expect(response.body).to match(/"openapi":"3.0.3"/)
       # puts response.body
 
-      expect(JSON::Validator.validate(swagger_schema, response.body)).to be_truthy
+      expect(response.body).to match_json_schema(swagger_schema)
     end
 
     it "does not output swagger when format is not json even if type is swagger" do

--- a/spec/dummy/app/controllers/users_controller.rb
+++ b/spec/dummy/app/controllers/users_controller.rb
@@ -293,6 +293,7 @@ class UsersController < ApplicationController
   header :RequredHeaderName, 'Required header description', required: true
   header :OptionalHeaderName, 'Optional header description', required: false, type: 'string'
   header :HeaderNameWithDefaultValue, 'Header with default value', required: true, default: 'default value'
+  header :HeaderWithRequiredNull, 'Header where don\'t specify required'
   def action_with_headers
   end
 end

--- a/spec/lib/swagger/rake_swagger_spec.rb
+++ b/spec/lib/swagger/rake_swagger_spec.rb
@@ -98,7 +98,7 @@ describe 'rake tasks' do
 
       it "generates a valid swagger file" do
         # print apidoc_swagger_json
-        expect(JSON::Validator.validate(swagger_schema, apidoc_swagger_json)).to be_truthy
+        expect(apidoc_swagger_json).to match_json_schema(swagger_schema)
       end
     end
 
@@ -126,7 +126,7 @@ describe 'rake tasks' do
 
       it "generates a valid swagger file" do
         # print apidoc_swagger_json
-        expect(JSON::Validator.validate(swagger_schema, apidoc_swagger_json)).to be_truthy
+        expect(apidoc_swagger_json).to match_json_schema(swagger_schema)
       end
     end
 

--- a/spec/lib/swagger/swagger_dsl_spec.rb
+++ b/spec/lib/swagger/swagger_dsl_spec.rb
@@ -50,7 +50,15 @@ describe "Swagger Responses" do
     matching[0]
   end
 
+  shared_examples_for "meta schema validation" do
+    let(:swagger_meta_schema) do
+      JSON.parse(File.read(File.join(File.dirname(__FILE__), 'openapi_3_0_schema.json')))
+    end
 
+    it "produces a valid schema" do
+      expect(openapi_schema).to match_json_schema(swagger_meta_schema)
+    end
+  end
 
 
   #
@@ -121,7 +129,7 @@ describe "Swagger Responses" do
 
 
   describe PetsController do
-
+    include_examples "meta schema validation"
 
     describe "PetsController#index" do
       subject do
@@ -471,6 +479,8 @@ describe "Swagger Responses" do
   #==============================================================================
 
   describe TaggedDogsController do
+    include_examples "meta schema validation"
+
     describe "TaggedDogsController#show_as_properties" do
       subject do
         desc._methods[:show_as_properties]
@@ -492,6 +502,8 @@ describe "Swagger Responses" do
   #==============================================================================
 
   describe TaggedCatsController do
+    include_examples "meta schema validation"
+
     describe "TaggedCatsController#show_as_properties" do
       subject do
         desc._methods[:show_as_properties]
@@ -527,6 +539,7 @@ describe "Swagger Responses" do
 
 
   describe PetsUsingSelfDescribingClassesController do
+    include_examples "meta schema validation"
 
     describe "PetsController#pets_described_as_class" do
       subject do
@@ -631,6 +644,7 @@ describe "Swagger Responses" do
   #=========================================================
 
   describe PetsUsingAutoViewsController do
+    include_examples "meta schema validation"
 
     describe "PetsController#pet_described_using_automated_view" do
       subject do
@@ -664,6 +678,8 @@ describe "Swagger Responses" do
   # UsersController is used for validation of header params
   #========================================================
   describe UsersController do
+    include_examples "meta schema validation"
+
     describe "Headers" do
       it "should have correct required property" do
         get_action = openapi_schema.dig(:paths, '/users/action_with_headers', 'get')

--- a/spec/lib/swagger/swagger_dsl_spec.rb
+++ b/spec/lib/swagger/swagger_dsl_spec.rb
@@ -660,5 +660,28 @@ describe "Swagger Responses" do
     end
   end
 
+  #========================================================
+  # UsersController is used for validation of header params
+  #========================================================
+  describe UsersController do
+    describe "Headers" do
+      it "should have correct required property" do
+        get_action = openapi_schema.dig(:paths, '/users/action_with_headers', 'get')
+        headers = get_action&.dig(:parameters)
+                    &.filter { |p| p[:in] == 'header' }
+                    &.index_by { |p| p[:name] }
+        headers.each do |_k, h|
+          (expect(h["required"]).not.to be(nil)) if h.key?("required")
+        end
+        expect(headers[:HeaderWithRequiredNull]).to eq({
+                                                         "name": :HeaderWithRequiredNull,
+                                                         "in": "header",
+                                                         "required": false,
+                                                         "description": "Header where don't specify required",
+                                                         "schema": { "type": "string" }
+                                                       } )
+      end
+    end
+  end
 
 end

--- a/spec/lib/swagger/swagger_gen_one_of_spec.rb
+++ b/spec/lib/swagger/swagger_gen_one_of_spec.rb
@@ -38,7 +38,7 @@ describe 'one of swagger gen' do
 
   describe 'apipie:static_swagger_json[development,json,_tmp]' do
     it 'generates a valid swagger file' do
-      expect(JSON::Validator.validate(swagger_schema, apidoc_swagger_json)).to be_truthy
+      expect(apidoc_swagger_json).to match_json_schema(swagger_schema)
     end
 
     it 'generates static swagger files for the default version of apipie docs' do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -74,6 +74,19 @@ RSpec::Matchers.define :have_field do |name, type, opts={}|
   end
 end
 
+RSpec::Matchers.define :match_json_schema do |expected_schema|
+  match do |actual|
+    errors = JSON::Validator.fully_validate(expected_schema, actual, validate_schema: true)
+
+    errors.empty?
+  end
+
+  failure_message do |actual|
+    errors = JSON::Validator.fully_validate(expected_schema, actual, validate_schema: true)
+    "Object expected to match json schema but found validation errors\n\n" + errors.join("\n")
+  end
+end
+
 # Requires supporting ruby files with custom matchers and macros, etc,
 # in spec/support/ and its subdirectories.
 Dir[File.expand_path("../support/**/*.rb", __FILE__)].each {|f| require f}


### PR DESCRIPTION
The OpenApi spec defined `parameters.required` as an optional boolean (ie. `null` is not a valid value).

Make this generator always defined `required`