### PR TITLE
[ADS-13423] Allow optional generation of swagger params with a full path

### DIFF
--- a/lib/apipie/param_description.rb
+++ b/lib/apipie/param_description.rb
@@ -142,7 +142,7 @@ module Apipie
 
     def full_path
       path = parents_and_self.map { |p| p.name if p.show }.compact.join("_")
-      return [name.to_s] if name_parts.blank?
+      return [name.to_s] if path.blank?
       return path
     end
 

--- a/lib/apipie/param_description.rb
+++ b/lib/apipie/param_description.rb
@@ -141,7 +141,7 @@ module Apipie
     end
 
     def full_path
-      path = parents_and_self.map { |p| p.name if p.show }.compact.join("_")
+      path = parents_and_self.map { |p| p.name if p.show }.compact
       return [name.to_s] if path.blank?
       return path
     end

--- a/lib/apipie/param_description.rb
+++ b/lib/apipie/param_description.rb
@@ -135,9 +135,15 @@ module Apipie
     end
 
     def full_name
-      name_parts = parents_and_self.map{|p| p.name if p.show}.compact
-      return name.to_s if name_parts.blank?
+      name_parts = full_path
+      return name.to_s if name_parts.length <= 1
       return ([name_parts.first] + name_parts[1..-1].map { |n| "[#{n}]" }).join("")
+    end
+
+    def full_path
+      path = parents_and_self.map { |p| p.name if p.show }.compact.join("_")
+      return [name.to_s] if name_parts.blank?
+      return path
     end
 
     # returns an array of all the parents: starting with the root parent

--- a/lib/apipie/swagger_generator.rb
+++ b/lib/apipie/swagger_generator.rb
@@ -508,7 +508,7 @@ module Apipie
           end
 
           ref_path = gen_referenced_block_from_params_array(
-            ref_name_from_param_desc(param, ind, true),
+            ref_name_from_param_desc(param, ind),
             param.validator.params_ordered,
             allow_nulls
           )
@@ -592,10 +592,11 @@ module Apipie
       "#/components/schemas/#{name}"
     end
 
-    def ref_name_from_param_desc(param_desc, name_fallback = '', use_full_path = false)
+    def ref_name_from_param_desc(param_desc, name_fallback = '')
       op_id = swagger_op_id_for_path(param_desc.method_description.apis.first.http_method,
                                      param_desc.method_description.apis.first.path)
-      name = use_full_path ? param_desc.full_path.join('_') : param_desc.name
+      part_of_one_of = param_desc.parents_and_self.any? { |pd| swagger_param_type(pd) == 'oneOf' }
+      name = part_of_one_of ? param_desc.full_path.join('_') : param_desc.name
       "#{op_id}_param_#{name || name_fallback}"
     end
 

--- a/lib/apipie/swagger_generator.rb
+++ b/lib/apipie/swagger_generator.rb
@@ -595,7 +595,7 @@ module Apipie
     def ref_name_from_param_desc(param_desc, name_fallback = '')
       op_id = swagger_op_id_for_path(param_desc.method_description.apis.first.http_method,
                                      param_desc.method_description.apis.first.path)
-      "#{op_id}_param_#{param_desc.name || name_fallback}"
+      "#{op_id}_param_#{param_desc.full_name || name_fallback}"
     end
 
     def put_schema_reference(name, schema_obj)

--- a/lib/apipie/swagger_generator.rb
+++ b/lib/apipie/swagger_generator.rb
@@ -595,8 +595,7 @@ module Apipie
     def ref_name_from_param_desc(param_desc, name_fallback = '')
       op_id = swagger_op_id_for_path(param_desc.method_description.apis.first.http_method,
                                      param_desc.method_description.apis.first.path)
-      part_of_one_of = param_desc.parents_and_self.any? { |pd| swagger_param_type(pd) == 'oneOf' }
-      name = part_of_one_of ? param_desc.full_path.join('_') : param_desc.name
+      name = param_desc.options[:unique_param_names] ? param_desc.full_path.join('_') : param_desc.name
       "#{op_id}_param_#{name || name_fallback}"
     end
 

--- a/lib/apipie/swagger_generator.rb
+++ b/lib/apipie/swagger_generator.rb
@@ -595,7 +595,7 @@ module Apipie
     def ref_name_from_param_desc(param_desc, name_fallback = '')
       op_id = swagger_op_id_for_path(param_desc.method_description.apis.first.http_method,
                                      param_desc.method_description.apis.first.path)
-      "#{op_id}_param_#{param_desc.full_name || name_fallback}"
+      "#{op_id}_param_#{param_desc.full_path.join("_") || name_fallback}"
     end
 
     def put_schema_reference(name, schema_obj)

--- a/lib/apipie/swagger_generator.rb
+++ b/lib/apipie/swagger_generator.rb
@@ -508,7 +508,7 @@ module Apipie
           end
 
           ref_path = gen_referenced_block_from_params_array(
-            ref_name_from_param_desc(param, ind),
+            ref_name_from_param_desc(param, ind, true),
             param.validator.params_ordered,
             allow_nulls
           )
@@ -592,10 +592,11 @@ module Apipie
       "#/components/schemas/#{name}"
     end
 
-    def ref_name_from_param_desc(param_desc, name_fallback = '')
+    def ref_name_from_param_desc(param_desc, name_fallback = '', use_full_path = false)
       op_id = swagger_op_id_for_path(param_desc.method_description.apis.first.http_method,
                                      param_desc.method_description.apis.first.path)
-      "#{op_id}_param_#{param_desc.full_path.join("_") || name_fallback}"
+      name = use_full_path ? param_desc.full_path.join('_') : param_desc.name
+      "#{op_id}_param_#{name || name_fallback}"
     end
 
     def put_schema_reference(name, schema_obj)


### PR DESCRIPTION
Problem:

It's possible for apipie to generate swagger containing params with duplicate names. This can cause validation errors since a given param may refer to multiple different api schemas.

Solution:

Add a new param option `uniqe_param_names` that can be set to tell `apipie` to generate a param name with the full path to prevent conflicts.