### PR TITLE
Always use unique names for schema refs

### DIFF
--- a/lib/apipie/swagger_generator.rb
+++ b/lib/apipie/swagger_generator.rb
@@ -595,7 +595,7 @@ module Apipie
     def ref_name_from_param_desc(param_desc, name_fallback = '')
       op_id = swagger_op_id_for_path(param_desc.method_description.apis.first.http_method,
                                      param_desc.method_description.apis.first.path)
-      name = param_desc.options[:unique_param_names] ? param_desc.full_path.join('_') : param_desc.name
+      name = param_desc.full_path.join('_')
       "#{op_id}_param_#{name || name_fallback}"
     end
 

--- a/spec/lib/swagger/swagger_gen_one_of_spec.rb
+++ b/spec/lib/swagger/swagger_gen_one_of_spec.rb
@@ -55,8 +55,8 @@ describe 'one of swagger gen' do
     it 'includes expected schemas' do
       schemas = apidoc_swagger['components']['schemas']
 
-      expect(schemas['get_pets_param_tag_id']['oneOf']).to match_array [{ type: 'integer', format: 'int64' },
-                                                                        { type: 'string' }]
+      expect(schemas['get_pets_param_dog_tag_id']['oneOf']).to match_array [{ type: 'integer', format: 'int64' },
+                                                                            { type: 'string' }]
 
       expect(schemas['get_pets_param_data']['oneOf']).to match_array [{ "$ref": '#/components/schemas/get_pets_param_dog' },
                                                                       { "$ref": '#/components/schemas/get_pets_param_cat' }]


### PR DESCRIPTION
This PR modifies the schema ref naming logic to use full param paths (introduced in #8) without requiring the `:unique_param_names` option.