### PR TITLE
[ADS-12559] Add NestedHashValidator with OpenAPI gen support

### DIFF
--- a/lib/apipie-rails.rb
+++ b/lib/apipie-rails.rb
@@ -19,6 +19,7 @@ require "apipie/response_description_adapter"
 require "apipie/see_description"
 require "apipie/tag_list_description"
 require "apipie/validator"
+require "apipie/validator/nested_hash_validator"
 require "apipie/validator/one_of_validator"
 require "apipie/railtie"
 require 'apipie/extractor'

--- a/lib/apipie/validator.rb
+++ b/lib/apipie/validator.rb
@@ -334,7 +334,7 @@ module Apipie
       include Apipie::DSL::Param
 
       def self.build(param_description, argument, options, block)
-        self.new(param_description, block, options[:param_group]) if block.is_a?(Proc) && block.arity <= 0 && argument == Hash
+        self.new(param_description, block, options[:param_group]) if block.is_a?(Proc) && block.arity <= 0 && argument == Hash && options[:of].blank?
       end
 
       def initialize(param_description, argument, param_group)

--- a/lib/apipie/validator/nested_hash_validator.rb
+++ b/lib/apipie/validator/nested_hash_validator.rb
@@ -1,0 +1,64 @@
+module Apipie
+  module Validator
+    class NestedHashValidator < BaseValidator
+      ITEMS_OPTIONS_EXCLUDE = %i[of desc].freeze
+
+      def initialize(param_description, values_argument, options = {}, block = nil)
+        super(param_description)
+
+        values_param_description = Apipie::ParamDescription.new(
+          param_description.method_description,
+          param_description.name,
+          values_argument,
+          nil,
+          options.reject { |k, _| ITEMS_OPTIONS_EXCLUDE.include?(k) },
+          &block
+        )
+        @validator = values_param_description.validator
+        @type = Hash
+      end
+
+      def validate(value)
+        value ||= {}
+        return false if value.class != Hash
+
+        value.values.all? do |child|
+          @validator.validate(child)
+        end
+      end
+
+      def process_value(value)
+        value ||= {}
+        value.transform_values do |value|
+          @validator.process_value(value)
+        end
+      end
+
+      def self.build(param_description, argument, options, block)
+        # in Ruby 1.8.x the arity on block without args is -1
+        # while in Ruby 1.9+ it is 0
+        return unless argument == Hash && options[:of].present?
+
+        values_argument = options.fetch(:of, String)
+
+        new(param_description, values_argument, options, block)
+      end
+
+      def expected_type
+        'hash'
+      end
+
+      def description
+        'Must be a Hash of nested elements'
+      end
+
+      def params_ordered
+        @validator.params_ordered
+      end
+
+      def values_validator
+        @validator
+      end
+    end
+  end
+end

--- a/spec/dummy/app/controllers/pets_one_of_controller.rb
+++ b/spec/dummy/app/controllers/pets_one_of_controller.rb
@@ -14,6 +14,7 @@ class PetsOneOfController < ApplicationController
   def_param_group :pet_common do
     param :name, String, desc: 'Name of pet'
     param :age, Integer, desc: 'Age of pet in years'
+    param :numeric_attributes, Hash, of: Integer
   end
 
   def_param_group :dog do
@@ -30,6 +31,13 @@ class PetsOneOfController < ApplicationController
     param :animal_type, ['cat'], desc: 'Type of pet'
     param_group :pet_common, PetsOneOfController
     param :meow_frequency, :decimal, desc: "The fundamental frequency of the cat's meow in hertz"
+    param :meow_types, Hash, of: :one_of do
+      param :meow_description, Hash do
+        param :volume, :decimal
+        param :tone, :decimal
+        param :timbre, String
+      end
+    end
   end
 
   def_param_group :pet do

--- a/spec/lib/swagger/swagger_gen_nested_hash_spec.rb
+++ b/spec/lib/swagger/swagger_gen_nested_hash_spec.rb
@@ -1,0 +1,68 @@
+require 'spec_helper'
+require 'json-schema'
+
+require File.expand_path('../../../dummy/app/controllers/pets_one_of_controller.rb', __FILE__)
+
+describe 'nested hash swagger gen' do
+  include_context 'rake'
+
+  let(:doc_path) { 'user_specified_doc_path' }
+
+  before do
+    Apipie.configuration.doc_path = doc_path
+    Apipie.configuration.swagger_suppress_warnings = true
+    allow(Apipie).to receive(:reload_documentation)
+    subject.invoke(*task_args)
+  end
+
+  after do
+    Dir["#{doc_output}*"].each { |static_file| FileUtils.rm_rf(static_file) }
+  end
+
+  let(:swagger_schema) do
+    File.read(File.join(File.dirname(__FILE__), 'openapi_3_0_schema.json'))
+  end
+
+  let(:apidoc_swagger_json) do
+    # note:  the filename ends with '_tmp' because this suffix is passed as a parameter to the rake task
+    File.read("#{doc_output}/schema_swagger_tmp.json")
+  end
+
+  let(:apidoc_swagger) do
+    HashWithIndifferentAccess.new(JSON.parse(apidoc_swagger_json))
+  end
+
+  let(:doc_output) do
+    File.join(::Rails.root, doc_path, 'apidoc')
+  end
+
+  describe 'apipie:static_swagger_json[development,json,_tmp]' do
+    it 'generates a valid swagger file' do
+      expect(apidoc_swagger_json).to match_json_schema(swagger_schema)
+    end
+
+    it 'generates static swagger files for the default version of apipie docs' do
+      expect(apidoc_swagger['info']['title']).to eq('Test app (params in:body)')
+      expect(apidoc_swagger['info']['version']).to eq Apipie.configuration.default_version.to_s
+    end
+
+    it 'includes expected paths' do
+      paths = apidoc_swagger['paths']
+      expect(paths['/pets'].values.count).to be 2
+      expect(paths['/pets/{id}'].values.count).to be 1
+    end
+
+    it 'includes expected schemas' do
+      schemas = apidoc_swagger['components']['schemas']
+
+      puts JSON.dump(schemas)
+
+      expect(schemas.dig(:get_pets_param_dog, :properties, :numeric_attributes, :type)).to eq 'object'
+      expect(schemas.dig(:get_pets_param_dog, :properties, :numeric_attributes, :additionalProperties)).to eq("type" => "integer", "format" => "int64")
+
+      expect(schemas.dig(:get_pets_param_cat, :properties, :meow_types, :additionalProperties, :'$ref')).to eq "#/components/schemas/get_pets_param_cat_meow_types_values"
+      expect(schemas.dig(:get_pets_param_cat_meow_types_values, :type)).to eq 'object'
+      expect(schemas.dig(:get_pets_param_cat_meow_types_values, :properties).keys).to match_array %w[volume tone timbre]
+    end
+  end
+end

--- a/spec/lib/validators/nested_hash_validator_spec.rb
+++ b/spec/lib/validators/nested_hash_validator_spec.rb
@@ -1,0 +1,55 @@
+require 'spec_helper'
+
+describe Apipie::Validator::NestedHashValidator do
+  before do
+    Apipie.configuration.validate = true
+    Apipie.configuration.validate_presence = true
+    Apipie.configuration.validate_value = true
+  end
+
+  let(:dsl_data) { ActionController::Base.send(:_apipie_dsl_data_init) }
+  let(:resource_desc) { Apipie::ResourceDescription.new(UsersController, 'users') }
+  let(:method_desc) { Apipie::MethodDescription.new(:show, resource_desc, dsl_data) }
+  let(:param_desc) { Apipie::ParamDescription.new(method_desc, :param, nil) }
+  let(:argument) { described_class::VALIDATOR_TYPE }
+
+  before do
+    Apipie.add_param_group UsersController, :param_group_a do
+      param :str, String, required: true
+      param :int, Integer, required: true
+    end
+
+    Apipie.add_param_group UsersController, :param_group_b do
+      param :id, :number, required: true
+      param :name, String, required: true
+      param :email, String
+    end
+  end
+
+  it 'works with a primitive type' do
+    validator = described_class.new(param_desc, Integer)
+    expect(validator.validate(20)).to be false
+    expect(validator.validate({ key: 'foo' })).to be false
+    expect(validator.validate({ key: 20 })).to be true
+    expect(validator.validate({ key: 20, foo: 10, bar: 2 })).to be true
+  end
+
+  it 'works with a nested hash type' do
+    validator = described_class.new(param_desc, Hash, {}, lambda {
+      param :foo, String
+    })
+    expect(validator.validate({ key: 'foo' })).to be false
+    expect(validator.validate({ key: 20 })).to be false
+    expect(validator.validate({ key: { foo: 'bar' } })).to be true
+  end
+
+  it 'works with one_of validator' do
+    validator = described_class.new(param_desc, :one_of, {}, lambda {
+      param :str, String
+      param :int, Integer
+    })
+    expect(validator.validate({ foo: 'bar', bar: 10 })).to be true
+    expect(validator.validate({ foo: 'bar', bar: 2.1 })).to be false
+    expect(validator.validate({ foo: {}, bar: 10 })).to be false
+  end
+end


### PR DESCRIPTION
This PR adds a new validator, `NestedHashValidator`, which enables specifying a value type for a `Hash` with arbitrary keys. The validator is supported in OpenAPI/Swagger schema generation by filling in the [`additionalProperties`](https://swagger.io/specification/#model-with-mapdictionary-properties) key available on `object` types.