### PR TITLE
A default placeholder validator for bulk params

### DIFF
--- a/Gemfile.rails50
+++ b/Gemfile.rails50
@@ -1,9 +1,10 @@
-source "https://rubygems.org"
+source 'https://rubygems.org'
 
 gemspec
 
-gem 'rails', '~> 5.0.0'
 gem 'mime-types', '~> 2.99.3'
+gem 'rails', '~> 5.0.0'
 gem 'rails-controller-testing'
+gem 'sqlite3', '~> 1.3.6'
 
 gem 'test_engine', path: 'spec/dummy/components/test_engine', group: :test

--- a/README.rst
+++ b/README.rst
@@ -1316,6 +1316,18 @@ description of nested values.
      param :comment, String, :desc => "Full comment", :required => true
    end
 
+BulkValidator
+-------------
+
+BulkValidator is only a placeholder validator which always return true for bulk params. BulkValidator is introduced because we need to bypass apipie validation for our bulk params and create its own non-apipie validation logic without touching other endpoints.
+
+.. code:: ruby
+
+   param :bulk_params, :bulk, :desc => "Bulk params" do
+     param :id, String, :desc => "Id of keyword", :required => true
+     param :keyword, String, :desc => "Keyword", :required => true
+   end   
+
 
 OneOfValidator
 --------------

--- a/lib/apipie-rails.rb
+++ b/lib/apipie-rails.rb
@@ -21,6 +21,7 @@ require "apipie/tag_list_description"
 require "apipie/validator"
 require "apipie/validator/nested_hash_validator"
 require "apipie/validator/one_of_validator"
+require "apipie/validator/bulk_validator"
 require "apipie/railtie"
 require 'apipie/extractor'
 require "apipie/version"

--- a/lib/apipie/validator/bulk_validator.rb
+++ b/lib/apipie/validator/bulk_validator.rb
@@ -1,0 +1,43 @@
+module Apipie
+  module Validator
+    class BulkValidator < BaseValidator
+      include Apipie::DSL::Base
+      include Apipie::DSL::Param
+
+      VALIDATOR_TYPE = :bulk
+
+      def initialize(param_description, block)
+        raise ArgumentError, 'A block must be provided' unless block.present? && block.is_a?(Proc)
+
+        super(param_description)
+
+        @proc = block
+        @type = :bulk
+
+        instance_exec(&@proc)
+      end
+
+      def validate(value)
+        # always return true for the apipie validator, we use our own validator to do the real param validation
+        return true
+        end
+      end
+
+      def process_value(value)
+      end
+
+      def self.build(param_description, argument, options, block)
+        return unless argument == VALIDATOR_TYPE && block.is_a?(Proc) && block.arity <= 0
+        new(param_description, block)
+      end
+
+      def expected_type
+        'bulk'
+      end
+
+      def description
+        'Must be a bulk type for bulk params'
+      end
+    end
+  end
+end

--- a/lib/apipie/validator/bulk_validator.rb
+++ b/lib/apipie/validator/bulk_validator.rb
@@ -17,17 +17,16 @@ module Apipie
         instance_exec(&@proc)
       end
 
-      def validate(value)
+      def validate(_value)
         # always return true for the apipie validator, we use our own validator to do the real param validation
-        return true
-        end
+        true
       end
 
-      def process_value(value)
-      end
+      def process_value(value); end
 
-      def self.build(param_description, argument, options, block)
+      def self.build(param_description, argument, _options, block)
         return unless argument == VALIDATOR_TYPE && block.is_a?(Proc) && block.arity <= 0
+
         new(param_description, block)
       end
 

--- a/spec/lib/validators/bulk_validator_spec.rb
+++ b/spec/lib/validators/bulk_validator_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe Apipie::Validator::BulkfValidator do
+describe Apipie::Validator::BulkValidator do
   before do
     Apipie.configuration.validate = true
     Apipie.configuration.validate_presence = true
@@ -13,19 +13,6 @@ describe Apipie::Validator::BulkfValidator do
   let(:param_desc) { Apipie::ParamDescription.new(method_desc, :param, nil) }
   let(:argument) { described_class::VALIDATOR_TYPE }
 
-  before do
-    Apipie.add_param_group UsersController, :param_group_a do
-      param :str, String, required: true
-      param :int, Integer, required: true
-    end
-
-    Apipie.add_param_group UsersController, :param_group_b do
-      param :id, :number, required: true
-      param :name, String, required: true
-      param :email, String
-    end
-  end
-
   it 'throws an error when no block is provided' do
     expect { described_class.new(param_desc, nil) }.to raise_error ArgumentError
   end
@@ -35,7 +22,7 @@ describe Apipie::Validator::BulkfValidator do
       param :str, String
     })
     expect(validator.validate('hello')).to be true
-    expect(validator.validate(nil)).to be true
+    expect(validator.validate(20)).to be true
   end
 
   it 'always return true after pass the block check' do

--- a/spec/lib/validators/bulk_validator_spec.rb
+++ b/spec/lib/validators/bulk_validator_spec.rb
@@ -1,0 +1,52 @@
+require 'spec_helper'
+
+describe Apipie::Validator::BulkfValidator do
+  before do
+    Apipie.configuration.validate = true
+    Apipie.configuration.validate_presence = true
+    Apipie.configuration.validate_value = true
+  end
+
+  let(:dsl_data) { ActionController::Base.send(:_apipie_dsl_data_init) }
+  let(:resource_desc) { Apipie::ResourceDescription.new(UsersController, 'users') }
+  let(:method_desc) { Apipie::MethodDescription.new(:show, resource_desc, dsl_data) }
+  let(:param_desc) { Apipie::ParamDescription.new(method_desc, :param, nil) }
+  let(:argument) { described_class::VALIDATOR_TYPE }
+
+  before do
+    Apipie.add_param_group UsersController, :param_group_a do
+      param :str, String, required: true
+      param :int, Integer, required: true
+    end
+
+    Apipie.add_param_group UsersController, :param_group_b do
+      param :id, :number, required: true
+      param :name, String, required: true
+      param :email, String
+    end
+  end
+
+  it 'throws an error when no block is provided' do
+    expect { described_class.new(param_desc, nil) }.to raise_error ArgumentError
+  end
+
+  it 'works with a single primitive type' do
+    validator = described_class.new(param_desc, lambda {
+      param :str, String
+    })
+    expect(validator.validate('hello')).to be true
+    expect(validator.validate(nil)).to be true
+  end
+
+  it 'always return true after pass the block check' do
+    validator = described_class.new(param_desc, lambda {
+      param nil, Hash do
+        param :foo, String, required: true
+        param :baz, String
+      end
+    })
+
+    expect(validator.validate({ foo: 'bar' })).to be true
+    expect(validator.validate({ foo: 'bar', baz: 'bar2' })).to be true
+  end
+end


### PR DESCRIPTION
We need this default `bulk_validator` to always return true so that other endpoints can still use apipie validation and bulk update endpoints can have its own custom validation strategy. 