### PR TITLE
[ads-backend] Allow NestedHashValidator to accept subclasses of Hash

### DIFF
--- a/lib/apipie/validator/nested_hash_validator.rb
+++ b/lib/apipie/validator/nested_hash_validator.rb
@@ -20,7 +20,7 @@ module Apipie
 
       def validate(value)
         value ||= {}
-        return false if value.class != Hash
+        return false unless value.is_a? Hash
 
         value.values.all? do |child|
           @validator.validate(child)


### PR DESCRIPTION
Currently, the `NestedHashValidator` checks that `value.class == Hash` which allows instances of `Hash`, but not instances of a *subclass* of Hash.

This PR updates the check to `value.is_a? Hash` to allow subclasses.