### PR TITLE
Fix the api doc for bulk validator

### DIFF
--- a/lib/apipie/swagger_generator.rb
+++ b/lib/apipie/swagger_generator.rb
@@ -495,6 +495,7 @@ module Apipie
                                 { type: 'string' }
                               end
       when 'bulk'
+        swagger_def[:type] = "array"
         swagger_def[:items] = {
           '$ref' => gen_referenced_block_from_params_array(
             ref_name_from_param_desc(param_desc),
@@ -572,7 +573,7 @@ module Apipie
                                              end
       end
 
-      if param_desc.is_array? || swagger_def[:type] == "bulk"
+      if param_desc.is_array?
         new_swagger_def = {
           items: swagger_def,
           type: 'array'

--- a/lib/apipie/swagger_generator.rb
+++ b/lib/apipie/swagger_generator.rb
@@ -572,7 +572,7 @@ module Apipie
                                              end
       end
 
-      if param_desc.is_array?
+      if param_desc.is_array? || swagger_def[:type] == "bulk"
         new_swagger_def = {
           items: swagger_def,
           type: 'array'


### PR DESCRIPTION
The API doc for bulk validator doesn't show the Body Parameter on the page as other validators do. The reason is because swagger_generator doesn't recognize bulk as a type. Set the type in swagger_generator to be `array` instead to allow bulk validator works as good as array validator.

Before: 
<img width="1213" alt="Screen Shot 2021-11-22 at 9 36 02 AM-20211122-143956" src="https://user-images.githubusercontent.com/77300776/145051904-3f594548-057a-4207-9194-ab983e243519.png">
After:
<img width="1551" alt="Screen Shot 2021-12-07 at 9 50 42 AM" src="https://user-images.githubusercontent.com/77300776/145051975-9b38df23-9dd0-43ca-a712-f70fe7e2f879.png">
